### PR TITLE
Fix rematch link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # What's Updux?
 
 So, I'm a fan of [Redux][]. Two days ago I discovered
-[rematch][] alonside a few other frameworks built atop Redux. 
+[rematch](https://rematch.github.io/rematch) alonside a few other frameworks built atop Redux. 
 
 It has a couple of pretty good ideas that removes some of the 
 boilerplate. Keeping mutations and asynchronous effects close to the 


### PR DESCRIPTION
Rematch.github.io doesn’t have a top-level page. Admittedly, a 404 for / is more a bug on their side, but this works for now.